### PR TITLE
Add point about code legibility

### DIFF
--- a/cultura.html
+++ b/cultura.html
@@ -14,7 +14,7 @@
   <li>Revisamos nuestro código vía Pull Requests. Nada pasa a master sin que haya sido aprobado por al menos otro miembro del equipo.</li>
   <li>Testamos nuestro código, o justificamos por qué en un caso concreto no es necesario hacerlo.</li>
   <li>Siempre tratamos de dejar el código mejor que cuando lo encontramos por primera vez.</li>
-  <li>Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido, pero siempre teniendo en mente que lo importante es que las personas puedan entender el código.</li>
+  <li>Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido y ampliamente extendidas, pero lo ignoraremos en donde su versión deje el código menos legible.</li>
   <li>Cuidamos la imagen que proyectamos al exterior entregando productos de los que nos sentimos orgullosos. Para ello es fundamental ponernos en el lugar del usuario y pensar en cómo va a utilizar cada nueva funcionalidad para hacerle la vida lo más fácil posible.</li>
 </ul>
 

--- a/cultura.html
+++ b/cultura.html
@@ -14,7 +14,7 @@
   <li>Revisamos nuestro código vía Pull Requests. Nada pasa a master sin que haya sido aprobado por al menos otro miembro del equipo.</li>
   <li>Testamos nuestro código, o justificamos por qué en un caso concreto no es necesario hacerlo.</li>
   <li>Siempre tratamos de dejar el código mejor que cuando lo encontramos por primera vez.</li>
-  <li>Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido y ampliamente extendidas, pero lo ignoraremos en donde su versión deje el código menos legible.</li>
+  <li>Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido y ampliamente extendidas, pero lo ignoraremos cuando su versión deje el código menos legible.</li>
   <li>Cuidamos la imagen que proyectamos al exterior entregando productos de los que nos sentimos orgullosos. Para ello es fundamental ponernos en el lugar del usuario y pensar en cómo va a utilizar cada nueva funcionalidad para hacerle la vida lo más fácil posible.</li>
 </ul>
 

--- a/cultura.html
+++ b/cultura.html
@@ -14,6 +14,7 @@
   <li>Revisamos nuestro código vía Pull Requests. Nada pasa a master sin que haya sido aprobado por al menos otro miembro del equipo.</li>
   <li>Testamos nuestro código, o justificamos por qué en un caso concreto no es necesario hacerlo.</li>
   <li>Siempre tratamos de dejar el código mejor que cuando lo encontramos por primera vez.</li>
+  <li>Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido, pero siempre teniendo en mente que lo importante es que las personas puedan entender el código.</li>
   <li>Cuidamos la imagen que proyectamos al exterior entregando productos de los que nos sentimos orgullosos. Para ello es fundamental ponernos en el lugar del usuario y pensar en cómo va a utilizar cada nueva funcionalidad para hacerle la vida lo más fácil posible.</li>
 </ul>
 

--- a/cultura.md
+++ b/cultura.md
@@ -11,7 +11,7 @@
 * Revisamos nuestro código vía Pull Requests. Nada pasa a master sin que haya sido aprobado por al menos otro miembro del equipo.
 * Testamos nuestro código, o justificamos por qué en un caso concreto no es necesario hacerlo.
 * Siempre tratamos de dejar el código mejor que cuando lo encontramos por primera vez.
-* Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido, pero siempre teniendo en mente que lo importante es que las personas puedan entender el código.
+* Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido y ampliamente extendidas, pero lo ignoraremos cuando su versión deje el código menos legible.
 * Cuidamos la imagen que proyectamos al exterior entregando productos de los que nos sentimos orgullosos. Para ello es fundamental ponernos en el lugar del usuario y pensar en cómo va a utilizar cada nueva funcionalidad.
 
 ## Eficiencia

--- a/cultura.md
+++ b/cultura.md
@@ -11,6 +11,7 @@
 * Revisamos nuestro código vía Pull Requests. Nada pasa a master sin que haya sido aprobado por al menos otro miembro del equipo.
 * Testamos nuestro código, o justificamos por qué en un caso concreto no es necesario hacerlo.
 * Siempre tratamos de dejar el código mejor que cuando lo encontramos por primera vez.
+* Siempre dejamos el código legible para el resto del equipo y nuestros yos del futuro. Generalmente haremos caso a las herramientas automáticas, que están basadas en convenciones con sentido, pero siempre teniendo en mente que lo importante es que las personas puedan entender el código.
 * Cuidamos la imagen que proyectamos al exterior entregando productos de los que nos sentimos orgullosos. Para ello es fundamental ponernos en el lugar del usuario y pensar en cómo va a utilizar cada nueva funcionalidad.
 
 ## Eficiencia


### PR DESCRIPTION
This is something I thought we can include here because it comes up frequently in PRs ("remember Hound is usually right, but you can ignore it if you think your way is more readable")

Also, if we're linking this doc from the job offer, we can skip explaining this in the offer itself, which is already quite long.